### PR TITLE
Add Dockerfile, build and run container examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM docker.io/ubuntu:20.04
+WORKDIR /tmp/motionplus
+COPY . .
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        autoconf automake autopoint pkgconf libtool libjpeg8-dev build-essential libzip-dev gettext libmicrohttpd-dev libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev git-core ffmpeg && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/ && \
+    autoreconf -fiv && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf /tmp/motionplus
+
+WORKDIR /usr/local/bin/
+
+ENTRYPOINT [ "/usr/local/bin/motionplus" ]
+CMD [ "-n" ]

--- a/doc/motionplus_build.html
+++ b/doc/motionplus_build.html
@@ -229,5 +229,14 @@
       <p></p>
     </ul>
 
+    <h3><a name=Docker_Build></a>  Building Docker Image</h3>
+    <ul>
+      <p></p>
+        <code><strong>cd ~</strong></code>
+        <br /><code><strong>git clone https://github.com/Motion-Project/motionplus.git</strong></code>
+        <br /><code><strong>cd motionplus</strong></code>
+        <br /><code><strong>docker build -f Dockerfile --tag localhost/"$USER"/motionplus:latest .</strong></code>
+    </ul>
+
   </section>
 </body>

--- a/doc/motionplus_examples.html
+++ b/doc/motionplus_examples.html
@@ -54,6 +54,7 @@
         <li> <a href="#haar_setup">Haar setup</a></li>
         <li> <a href="#hog_setup">HOG setup</a></li>
         <li> <a href="#dnn_setup">DNN setup</a></li>
+        <li> <a href="#docker">Docker</a></li>
         
         <p></p>
         <p></p>
@@ -229,6 +230,27 @@
           <li><code>framework</code>Default: none | </li>        
         </ul>
 
+      </ul>
+
+      <h3><a name="docker"></a>Docker</h3>
+      <ul>
+        <li> Build docker image locally <a href="motionplus_build.html#Docker_Build"> Building docker image from source </a></li>
+        <li>The configuration directory and files must be mounted unless you want to use the default configuration files.</li>
+        <li>Run Motionplus container </li>
+        <p></p>
+        <code>
+          docker run \<br>
+          --name motionplus \<br>
+          -d \<br>
+          --replace \<br>
+          -e TZ="America/New_York" \<br>
+          -v /usr/local/etc/motion:/usr/local/etc/motionplus \ # Configuration files<br>
+          -v /var/data/motionplus:/var/lib/motionplus \ # Movie files<br>
+          -p 8080:8080 \<br>
+          --device /dev/dri:/dev/dri \ # Video card device files<br>
+          localhost/"$USER"/motionplus:latest
+        </code>
+        <p></p>
       </ul>
 
  


### PR DESCRIPTION
Hello Motionplus project, I'd like to contribute by adding a Dockerfile.

Add Dockerfile to allow easily running Motionplus as a container.
Currently this will need to be locally built for use as shown in the examples.

Possibly this can be placed in a CI/CD pipeline once releases are going using the same/similar processes as Motion? I'm unsure of how Motion updates the docker hub image.