### PR TITLE
Issue a SIG_IGN before forking exec_commands

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1289,6 +1289,8 @@ void util_exec_command(ctx_dev *cam, const char *command, char *filename, int fi
         mystrftime(cam, stamp, sizeof(stamp), command, &cam->current_image->imgts, filename, filetype);
     }
 
+    // Tells the OS that we will not be waiting for this forks return code and it can be discarded immediately after it exits
+    signal(SIGCHLD,SIG_IGN);
     if (!fork()) {
         /* Detach from parent */
         setsid();


### PR DESCRIPTION
PR to document a work around which seems to have resolved a local issues with accumulating defunct sh processes (#77).

Please close immediately if this is not useful.

Seems to prevent defunct sh processes from accumulating by allowing the OS to clear down the wrapping sh processes as soon as the complete.

The OS was retaining these processes in case we were going to come back and read the return status. We are not interested so we can use SIG_IGN to tell the OS that it can release these processes immediately.